### PR TITLE
Only select nouns in query

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Last update on 26.10.2018
 
 License: CC0
 
-Source of the data: Wikidata https://wikidata.org  (query: http://tinyurl.com/yazso2mj)
+Source of the data: Wikidata https://wikidata.org  (query: http://tinyurl.com/y8xhz2rj)
 
 Special thanks to Lucas for the queries and Vigneron for the support
 

--- a/docs/lib.php
+++ b/docs/lib.php
@@ -15,6 +15,7 @@
 	  SELECT DISTINCT ?lemma WHERE {
 	    VALUES ?gender { wd:Q499327 wd:Q1775415 wd:Q1775461 }
 	    ?lexeme dct:language wd:Q188;
+	            wikibase:lexicalCategory wd:Q1084;
 	            wdt:P5185 ?gender;
 	            wikibase:lemma ?lemma.
 	  }


### PR DESCRIPTION
Nouns are not the only lexemes with a grammatical gender, but they are the only lexical category where articles are used (I think); for example, it does not make sense to ask the user whether “der dieser”, “die dieser” or “das dieser” is correct, as happened to me when I was trying out the game (see [L7881][1]).

[1]: https://www.wikidata.org/wiki/Lexeme:L7881

CC @Auregann (I’m not sure if you get notified about the pull request otherwise)