### PR TITLE
added filter to ensure only nouns with uppercase will be displayed

### DIFF
--- a/docs/clear.php
+++ b/docs/clear.php
@@ -12,6 +12,7 @@
 	    ?lexeme dct:language wd:Q188;
 	            wdt:P5185 ?gender;
 	            wikibase:lemma ?lemma.
+	    FILTER (LCASE(?lemma) != ?lemma)
 	  }
 	  ORDER BY CONCAT(MD5(?lemma), STR(NOW()))
 	  LIMIT 100


### PR DESCRIPTION
What I added is just ```    FILTER (LCASE(?lemma) != ?lemma)```
but the commit is larger because of the following notification:
``` We’ve detected the file has mixed line endings. When you commit changes we will normalize them to Windows-style (CRLF). ```

Learners should not be exposed to low-quality data, so it makes sense to add a check that the noun is capitalized.